### PR TITLE
Update Dockerfile to extend from the alpine image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3
+FROM python:3-alpine
 
 RUN apt-get update && \
     apt-get install -y jq libxml2-utils


### PR DESCRIPTION
`python:3` extends from Debian bullseye at 300+ MB. `python:3-alpine` is 16MB.